### PR TITLE
Support for pcap_create and associated functions

### DIFF
--- a/Pcap.pm
+++ b/Pcap.pm
@@ -33,6 +33,7 @@ my @func_short_names = qw(
     lib_version  createsrcstr  parsesrcstr  open  setbuff  setuserbuffer
     setmode  setmintocopy  getevent  sendpacket
     sendqueue_alloc  sendqueue_queue  sendqueue_transmit
+    create set_buffer_size set_promisc set_snaplen set_timeout activate
 );
 
 my @func_long_names = map { "pcap_$_" } @func_short_names;
@@ -110,7 +111,8 @@ my @func_long_names = map { "pcap_$_" } @func_short_names;
             createsrcstr  parsesrcstr
             setbuff  setuserbuffer  setmode  setmintocopy  getevent  sendpacket
             sendqueue_alloc  sendqueue_queue  sendqueue_transmit
-        )], 
+            create set_buffer_size set_promisc set_snaplen set_timeout activate
+        )],
     );
 
     @EXPORT = (
@@ -467,6 +469,23 @@ B<Example>
 
     $pcap = pcap_open_dead(0, 1024);
 
+=item B<pcap_create($dev, \$err)>
+
+Creates and returns a new packet descriptor for looking at
+packets on the network. The C<$dev> parameter specifies which network interface
+to capture packets from.  The packet descriptor will be undefined if an error
+occurs, and the C<$err> parameter will be set with an appropriate error message.
+
+The packet descriptor returned is B<not yet activated>. It allows you to set
+various parameter (eg. using pcap_set_buffer_size) that cannot be set on some
+plateforms when activated. To actually start capturing packets, you must
+activate it using C<pcap_activate()>.
+
+B<Example>
+
+    $pcap = pcap_create($dev, \$err);
+    ...
+    pcap_activate($pcap);
 
 =item B<pcap_open_offline($filename, \$err)>
 
@@ -479,6 +498,18 @@ B<Example>
 
     $pcap = pcap_open_offline($dump, \$err)
         or die "Can't read '$dump': $err\n";
+
+
+=item B<pcap_activate($pcap)>
+
+Start capturing packets on a packet descriptor created with C<pcap_create()>
+and not yet activated. Return 0 on success.
+
+B<Example>
+
+    $pcap = pcap_create($dev, \$err);
+    ...
+    $pcap = pcap_activate($pcap);
 
 
 =item B<pcap_loop($pcap, $count, \&callback, $user_data)>
@@ -719,6 +750,39 @@ B<Example>
 Sets the data link type of the given pcap descriptor to the type specified 
 by C<$linktype>. Returns -1 on failure. 
 
+=item B<pcap_set_buffer_size($pcap, $dim)>
+
+Sets the ring buffer size used to capture packets on packet descriptor. Given
+size unit is bytes.
+
+Returns 0 on success.
+
+=item B<pcap_set_promisc($pcap, $promisc)>
+
+Sets the promisc mode to use with the interface associated to the packet
+descriptor. '0' to deactivate, any other values to activate.
+
+Only possible if the packet descriptor is B<not yet activated>.
+
+Returns 0 on success.
+
+=item B<pcap_set_snaplen($pcap, $snaplen)>
+
+Sets the snapshot length to use to capture packets with the given packet
+descriptor. Maximum value is 65535.
+
+Only possible if the packet descriptor is B<not yet activated>.
+
+Returns 0 on success.
+
+=item B<pcap_set_timeout($pcap, $timeout)>
+
+Sets the read timeout that will be used with the given packet descriptor to
+to_ms, which is in units of milliseconds.
+
+Only possible if the packet descriptor is B<not yet activated>.
+
+Returns 0 on success.
 
 =item B<pcap_datalink_name_to_val($name)>
 

--- a/Pcap.xs
+++ b/Pcap.xs
@@ -1069,3 +1069,59 @@ pcap_sendqueue_transmit(p, queue, sync)
     pcap_send_queue * queue
     int sync
 
+
+pcap_t *
+pcap_create(source, err)
+    char *source
+    SV *err
+
+    CODE:
+        if (!SvROK(err))
+            croak("arg2 not a reference");
+
+	char    *errbuf = NULL;
+	SV      *err_sv = SvRV(err);
+
+	Newx(errbuf, PCAP_ERRBUF_SIZE+1, char);
+
+	RETVAL = pcap_create(source, errbuf); 
+
+	if (RETVAL == NULL) {
+	    sv_setpv(err_sv, errbuf);				
+	} else {
+	    err_sv = &PL_sv_undef;
+	}  	  
+
+	safefree(errbuf);
+
+    OUTPUT:
+        RETVAL
+        err
+
+
+int
+pcap_set_buffer_size(p, dim)
+    pcap_t *p
+    int dim
+
+
+int
+pcap_set_promisc(p, promisc)
+    pcap_t *p
+    int promisc
+
+
+int
+pcap_set_snaplen(p, snaplen)
+    pcap_t *p
+    int snaplen
+
+
+int
+pcap_set_timeout(p, timeout)
+    pcap_t *p
+    int timeout
+
+int
+pcap_activate(p)
+    pcap_t *p

--- a/stubs.inc
+++ b/stubs.inc
@@ -528,6 +528,89 @@ struct pcap_samp *pcap_setsampling(pcap_t *p) {
 }
 #endif
 
+#ifndef HAVE_PCAP_CREATE
+#ifdef __GNUC__
+#warning "the function pcap_create() is not available"
+#endif
+#ifdef _MSC_VER
+#pragma message( "Warning: the function pcap_create() is not available" )
+#endif
+pcap_t * pcap_create(pcap_t * p, char *err);
+pcap_t * pcap_create(pcap_t * p, char *err) {
+    FUNCTION_NOT_IMPLEMENTED_WARNING(pcap_create)
+    return NULL;
+}
+#endif
+
+#ifndef HAVE_PCAP_SET_BUFFER_SIZE
+#ifdef __GNUC__
+#warning "the function pcap_set_buffer_size() is not available"
+#endif
+#ifdef _MSC_VER
+#pragma message( "Warning: the function pcap_set_buffer_size() is not available" )
+#endif
+int pcap_set_buffer_size(pcap_t * p, int dim);
+int pcap_set_buffer_size(pcap_t * p, int dim) {
+    FUNCTION_NOT_IMPLEMENTED_ERROR(pcap_set_buffer_size)
+    return -1;
+}
+#endif
+
+#ifndef HAVE_PCAP_SET_PROMISC
+#ifdef __GNUC__
+#warning "the function pcap_set_promisc() is not available"
+#endif
+#ifdef _MSC_VER
+#pragma message( "Warning: the function pcap_set_promisc() is not available" )
+#endif
+int pcap_set_promisc(pcap_t * p, int promisc);
+int pcap_set_promisc(pcap_t * p, int promisc) {
+    FUNCTION_NOT_IMPLEMENTED_ERROR(pcap_set_promisc)
+    return -1;
+}
+#endif
+
+#ifndef HAVE_PCAP_SET_SNAPLEN
+#ifdef __GNUC__
+#warning "the function pcap_set_snaplen() is not available"
+#endif
+#ifdef _MSC_VER
+#pragma message( "Warning: the function pcap_set_snaplen() is not available" )
+#endif
+int pcap_set_snaplen(pcap_t * p, int snaplen);
+int pcap_set_snaplen(pcap_t * p, int snaplen) {
+    FUNCTION_NOT_IMPLEMENTED_ERROR(pcap_set_snaplen)
+    return -1;
+}
+#endif
+
+#ifndef HAVE_PCAP_SET_TIMEOUT
+#ifdef __GNUC__
+#warning "the function pcap_set_timeout() is not available"
+#endif
+#ifdef _MSC_VER
+#pragma message( "Warning: the function pcap_set_timeout() is not available" )
+#endif
+int pcap_set_timeout(pcap_t * p, int timeout);
+int pcap_set_timeout(pcap_t * p, int timeout) {
+    FUNCTION_NOT_IMPLEMENTED_ERROR(pcap_set_timeout)
+    return -1;
+}
+#endif
+
+#ifndef HAVE_PCAP_ACTIVATE
+#ifdef __GNUC__
+#warning "the function pcap_activate() is not available"
+#endif
+#ifdef _MSC_VER
+#pragma message( "Warning: the function pcap_activate() is not available" )
+#endif
+int pcap_activate(pcap_t * p);
+int pcap_activate(pcap_t * p) {
+    FUNCTION_NOT_IMPLEMENTED_ERROR(pcap_activate)
+    return -1;
+}
+#endif
 
 /*
 
@@ -547,3 +630,4 @@ void pcap_remoteact_cleanup();
 
 
 */
+

--- a/t/24-create.t
+++ b/t/24-create.t
@@ -1,0 +1,127 @@
+#!perl -T
+use strict;
+use Test::More;
+use Net::Pcap;
+use lib 't';
+use Utils;
+
+plan skip_all => "pcap_create() is not available" unless is_available('pcap_create');
+plan tests => 27;
+
+my $has_test_exception = eval "use Test::Exception; 1";
+
+my($dev,$pcap,$r,$err) = ('','','','');
+
+# Find a device and open it
+$dev = find_network_device();
+
+# Testing error messages
+SKIP: {
+    skip "Test::Exception not available", 12 unless $has_test_exception;
+
+    # pcap_create() errors
+    throws_ok(sub {
+        Net::Pcap::create()
+    }, '/^Usage: Net::Pcap::create\(source, err\)/',
+       "calling pcap_create() with no argument");
+
+    throws_ok(sub {
+        Net::Pcap::create(0, 0)
+    }, '/^arg2 not a reference/',
+       "calling pcap_create() with incorrect argument type for arg2");
+
+    # pcap_set_buffer_size() errors
+    throws_ok(sub {
+        Net::Pcap::set_buffer_size()
+    }, '/^Usage: Net::Pcap::set_buffer_size\(p, dim\)/',
+       "calling pcap_set_buffer_size() with no argument");
+
+    throws_ok(sub {
+        Net::Pcap::set_buffer_size(0, 0)
+    }, '/^p is not of type pcap_tPtr/',
+       "calling pcap_set_buffer_size() with incorrect pcap argument");
+
+    # set_promisc() errors
+    throws_ok(sub {
+        Net::Pcap::set_promisc()
+    }, '/^Usage: Net::Pcap::set_promisc\(p, promisc\)/',
+       "calling pcap_set_promisc() with no argument");
+
+    throws_ok(sub {
+        Net::Pcap::set_promisc(0, 0)
+    }, '/^p is not of type pcap_tPtr/',
+       "calling pcap_set_promisc() with incorrect pcap argument");
+
+    # pcap_set_snaplen() errors
+    throws_ok(sub {
+        Net::Pcap::set_snaplen()
+    }, '/^Usage: Net::Pcap::set_snaplen\(p, snaplen\)/',
+       "calling pcap_set_snaplen() with no argument");
+
+    throws_ok(sub {
+        Net::Pcap::set_snaplen(0, 0)
+    }, '/^p is not of type pcap_tPtr/',
+       "calling pcap_set_snaplen() with incorrect pcap argument");
+
+    # pcap_set_timeout() errors
+    throws_ok(sub {
+        Net::Pcap::set_timeout()
+    }, '/^Usage: Net::Pcap::set_timeout\(p, timeout\)/',
+       "calling pcap_set_timeout() with no argument");
+
+    throws_ok(sub {
+        Net::Pcap::set_timeout(0, 0)
+    }, '/^p is not of type pcap_tPtr/',
+       "calling pcap_set_timeout() with incorrect pcap argument");
+
+    # pcap_activate() errors
+    throws_ok(sub {
+        Net::Pcap::activate()
+    }, '/^Usage: Net::Pcap::activate\(p\)/',
+       "calling pcap_activate() with no argument");
+
+    throws_ok(sub {
+        Net::Pcap::activate(0)
+    }, '/^p is not of type pcap_tPtr/',
+       "calling pcap_activate() with incorrect pcap argument");
+}
+
+SKIP: {
+    skip "must be run as root", 15 unless is_allowed_to_use_pcap();
+    skip "no network device available", 15 unless find_network_device();
+
+    # Testing pcap_create()
+    $pcap = eval { Net::Pcap::create($dev, \$err) };
+    is( $@, '', "pcap_create()" );
+    is( $err, '', " - \$err must be null: $err" );
+    ok( defined $pcap, " - returned a defined value" );
+    isa_ok( $pcap, 'SCALAR', " - \$pcap" );
+    isa_ok( $pcap, 'pcap_tPtr', " - \$pcap" );
+
+    # Testing pcap_set_buffer_size()
+    $r = eval { Net::Pcap::set_buffer_size($pcap, 8*1024) };
+    is( $@, '', "pcap_set_buffer_size()" );
+    is( $r, 0, " - returns 0 for true" );
+
+    # Testing pcap_set_promisc()
+    $r = eval { Net::Pcap::set_promisc($pcap, 0) };
+    is( $@, '', "pcap_set_promisc()" );
+    is( $r, 0, " - returns 0 for true" );
+
+    # Testing pcap_set_snaplen()
+    $r = eval { Net::Pcap::set_snaplen($pcap, 1024) };
+    is( $@, '', "pcap_set_snaplen()" );
+    is( $r, 0, " - returns 0 for true" );
+
+    # Testing pcap_set_timeout()
+    $r = eval { Net::Pcap::set_timeout($pcap, 1000) };
+    is( $@, '', "pcap_set_timeout()" );
+    is( $r, 0, " - returns 0 for true" );
+
+    # Testing pcap_activate()
+    $r = eval { Net::Pcap::activate($pcap) };
+    is( $@, '', "pcap_activate()" );
+    is( $r, 0, " - returns 0 for true" );
+
+    Net::Pcap::close($pcap);
+}


### PR DESCRIPTION
Following the discussion on [issue 1](https://github.com/maddingue/Net-Pcap/issues/1), here is the pull request with the patch discussed with some tests added.

Functions added:
- pcap_create(): create a non activated pcap handler
- pcap_set_buffer_size(): set the capture buffer size on a non
  activated pcap handler
- pcap_set_promisc(): set the posmiscious mode on a non
  activated pcap handler
- pcap_set_snaplen(): set the snaplen on a non activated pcap handler
- pcap_set_timeout(): set the capture timeout on a non activated pcap
  handler
- pcap_activate(): activate a pcap handler created with pcap_create()

PS: sorry for being so late to answer this :(
