### PR TITLE
Allow error message to be a suffix

### DIFF
--- a/t/09-error.t
+++ b/t/09-error.t
@@ -22,7 +22,7 @@ is(   $@,   '', "compile() with an invalid filter string" );
 is(   $res, -1, " - result must not be null: $res" );
 eval { $err = Net::Pcap::geterr($pcap) };
 is(   $@,   '', "geterr()" );
-like( $err, '/^(?:parse|syntax) error$/', " - \$err must not be null: $err" );
+like( $err, '/(^|: )(?:parse|syntax) error$/', " - \$err must not be null: $err" );
 
 # Testing compile() with a valid filter
 eval { $res = Net::Pcap::compile($pcap, \$filter, "tcp", 0, $mask) };


### PR DESCRIPTION
Previously, the error message emitted by the native calls was of the
form:

    'syntax error'

However, more recently the error message takes the form:

    'syntax error in filter expression: syntax error'

This patch pretends the part before the ":" is functionally equivalent
to a line start, for the purposes of testing.

Closes: https://github.com/maddingue/Net-Pcap/issues/8